### PR TITLE
A new tool for benchmarking CGSuite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,9 @@ desktop-app/**/build/
 desktop-app/**/nbproject/build-impl.xml
 desktop-app/**/nbproject/genfiles.properties
 desktop-app/**/nbproject/private/
+desktop-app/cgsuite-core-lib/release/modules/ext/
 desktop-app/dist/
+
+# CGSuite-related
+cgsuite-kernel.log
+lib/core/local/

--- a/lib/core/pom.xml
+++ b/lib/core/pom.xml
@@ -1,157 +1,24 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <parent>
+    <groupId>org.cgsuite</groupId>
+    <artifactId>cgsuite</artifactId>
+    <version>2.0.0-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.cgsuite</groupId>
   <artifactId>cgsuite-core</artifactId>
-  <version>2.0.0</version>
   <packaging>jar</packaging>
   <name>${project.artifactId}</name>
   <description>Core CGSuite library and API.</description>
   <inceptionYear>2015</inceptionYear>
-  <licenses>
-    <license>
-      <name>GNU General Public License (GPL)</name>
-      <url>http://www.gnu.org/licenses/gpl.txt</url>
-      <distribution>repo</distribution>
-    </license>
-  </licenses>
-
-  <properties>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
-    <encoding>UTF-8</encoding>
-    <scala.tools.version>2.12</scala.tools.version>
-    <scala.version>2.12.8</scala.version>
-  </properties>
-
-  <dependencies>
-    <dependency>
-      <groupId>org.scala-lang</groupId>
-      <artifactId>scala-library</artifactId>
-      <version>${scala.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>com.typesafe.scala-logging</groupId>
-      <artifactId>scala-logging_${scala.tools.version}</artifactId>
-      <version>3.9.2</version>
-    </dependency>
-    <dependency>
-      <groupId>ch.qos.logback</groupId>
-      <artifactId>logback-classic</artifactId>
-      <version>1.1.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.antlr</groupId>
-      <artifactId>antlr</artifactId>
-      <version>3.5.2</version>
-    </dependency>
-    <dependency>
-      <groupId>cc.redberry</groupId>
-      <artifactId>rings.scaladsl_${scala.tools.version}</artifactId>
-      <version>2.5.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jline</groupId>
-      <artifactId>jline</artifactId>
-      <version>3.9.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jline</groupId>
-      <artifactId>jline-terminal-jansi</artifactId>
-      <version>3.9.0</version>
-    </dependency>
-    <dependency>
-      <groupId>io.methvin</groupId>
-      <artifactId>directory-watcher-better-files_${scala.tools.version}</artifactId>
-      <version>0.7.0</version>
-    </dependency>
-
-    <!-- Test -->
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.11</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.scalatest</groupId>
-      <artifactId>scalatest_${scala.tools.version}</artifactId>
-      <version>3.0.5</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.scalacheck</groupId>
-      <artifactId>scalacheck_${scala.tools.version}</artifactId>
-      <version>1.14.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.antlr</groupId>
-      <artifactId>gunit</artifactId>
-      <version>3.5.2</version>
-      <scope>test</scope>
-    </dependency>
-  </dependencies>
 
   <build>
-    <sourceDirectory>src/main/scala</sourceDirectory>
-    <testSourceDirectory>src/test/scala</testSourceDirectory>
+
     <plugins>
-      <plugin>
-        <!-- see http://davidb.github.com/scala-maven-plugin -->
-        <groupId>net.alchim31.maven</groupId>
-        <artifactId>scala-maven-plugin</artifactId>
-        <version>3.2.1</version>
-        <executions>
-          <execution>
-            <id>scala-compile-first</id>
-            <phase>process-resources</phase>
-            <goals>
-              <goal>compile</goal>
-            </goals>
-            <configuration>
-              <recompileMode>incremental</recompileMode>
-              <args>
-                <arg>-feature</arg>
-                <arg>-dependencyfile</arg>
-                <arg>${project.build.directory}/.scala_dependencies</arg>
-              </args>
-            </configuration>
-          </execution>
-          <execution>
-            <id>scala-test-first</id>
-            <phase>process-test-resources</phase>
-            <goals>
-              <goal>testCompile</goal>
-            </goals>
-            <configuration>
-              <recompileMode>incremental</recompileMode>
-              <args>
-                <arg>-dependencyfile</arg>
-                <arg>${project.build.directory}/.scala_dependencies</arg>
-              </args>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <version>3.1.0</version>
-        <configuration>
-          <descriptorRefs>
-            <descriptorRef>jar-with-dependencies</descriptorRef>
-          </descriptorRefs>
-        </configuration>
-        <executions>
-          <execution>
-            <id>assemble-all</id>
-            <phase>package</phase>
-            <goals>
-              <goal>single</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
+
+      <!-- antlr3-maven -->
       <plugin>
         <groupId>org.antlr</groupId>
         <artifactId>antlr3-maven-plugin</artifactId>
@@ -171,6 +38,8 @@
           </execution>
         </executions>
       </plugin>
+
+      <!-- exec-maven -->
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
@@ -192,49 +61,9 @@
           </arguments>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.13</version>
-        <configuration>
-          <skipTests>true</skipTests>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.scalatest</groupId>
-        <artifactId>scalatest-maven-plugin</artifactId>
-        <version>1.0</version>
-        <configuration>
-          <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
-          <junitxml>.</junitxml>
-          <filereports>WDF TestSuite.txt</filereports>
-          <forkMode>once</forkMode>
-          <argLine>-XX:MaxPermSize=256m</argLine>
-          <parallel>false</parallel>
-        </configuration>
-        <executions>
-          <execution>
-            <id>test</id>
-            <goals>
-              <goal>test</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <artifactId>maven-clean-plugin</artifactId>
-        <configuration>
-          <filesets>
-            <fileset>
-              <directory>src/main/gen</directory>
-              <includes>
-                <include>**/*</include>
-              </includes>
-              <followSymlinks>false</followSymlinks>
-            </fileset>
-          </filesets>
-        </configuration>
-      </plugin>
+
     </plugins>
+
   </build>
+
 </project>

--- a/lib/core/src/main/scala/org/cgsuite/tools/Benchmark.scala
+++ b/lib/core/src/main/scala/org/cgsuite/tools/Benchmark.scala
@@ -1,0 +1,156 @@
+package org.cgsuite.tools
+
+import java.io._
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+import org.cgsuite.lang.EvalUtil
+import org.hyperic.sigar.Sigar
+import org.slf4j.LoggerFactory
+
+import scala.collection.mutable
+
+object Benchmark {
+
+  val instances = Vector(
+    Instance("Initialization", "0"),
+    Instance("Warmup", """game.grid.Amazons("x|o"); game.grid.Clobber("x|o"); game.heap.Nim(20); game.strip.ToadsAndFrogs("t.f");"""),
+    Instance("Heated *14", """*14 Heat 1;"""),
+    Instance("Big Output", """*12 Heat 1"""),
+    Instance("Kayles 40000", "game.heap.Kayles(40000).NimValue;"),
+    Instance("Clobber 4x4", """game.grid.Clobber("xoxo|oxox|xoxo|oxox").CanonicalForm;"""),
+    Instance("Amazons 2x7", """game.grid.Amazons("x......|o......").CanonicalForm;"""),
+  )
+  val dateFormat = DateTimeFormatter.ofPattern("yyyy-MM-dd HH.mm.ss")
+
+  def main(args: Array[String]): Unit = {
+
+    run(args.length > 0 && args.head == "--console")
+
+  }
+
+  def run(consoleOnly: Boolean = true): Unit = {
+
+    val rootLogger = LoggerFactory.getLogger(org.slf4j.Logger.ROOT_LOGGER_NAME).asInstanceOf[ch.qos.logback.classic.Logger]
+    rootLogger.detachAndStopAllAppenders()
+
+    Benchmark(instances).run(consoleOnly)
+
+  }
+
+  def gitSha(): String = {
+    val process = Runtime.getRuntime.exec("git log")
+    val reader = new BufferedReader(new InputStreamReader(process.getInputStream))
+    val line = reader.readLine()
+    reader.close()
+    val sha = line.split(' ')(1)
+    sha
+  }
+
+  def gitBranch(): String = {
+    val process = Runtime.getRuntime.exec("git status")
+    val reader = new BufferedReader(new InputStreamReader(process.getInputStream))
+    val line = reader.readLine()
+    reader.close()
+    val branch = line.stripPrefix("On branch ")
+    branch
+  }
+
+  def gitHasLocalChanges(): Boolean = {
+    val process = Runtime.getRuntime.exec("git diff HEAD")
+    val reader = new BufferedReader(new InputStreamReader(process.getInputStream))
+    val line = reader.readLine()
+    reader.close()
+    line != null
+  }
+
+  case class Instance(name: String, command: String)
+
+}
+
+case class Benchmark(instances: Vector[Benchmark.Instance]) {
+
+  def run(consoleOnly: Boolean = true): Unit = {
+
+    val dateTime = Benchmark.dateFormat.format(LocalDateTime.now())
+    var writer: PrintWriter = null
+
+    val sha = Benchmark.gitSha()
+    val branch = Benchmark.gitBranch()
+
+    if (!consoleOnly) {
+      if (Benchmark.gitHasLocalChanges()) {
+        println("Git repo has local changes; please commit or stash (or re-run Benchmark with consoleOnly = true).")
+        return
+      }
+      val localDir = new File("local")
+      localDir.mkdir()
+      val output = new File(localDir, s"CGSuite Benchmark $dateTime.txt")
+      writer = new PrintWriter(new FileOutputStream(output))
+    }
+
+    println("CGSuite Benchmark\n")
+
+    val systemInformation =
+      s"""Date           : $dateTime
+         |CGSuite Version: 2.0
+         |Git Branch     : $branch
+         |Git SHA        : $sha
+         |Java Version   : ${util.Properties.javaVersion}
+         |Scala Version  : ${util.Properties.versionNumberString}
+         |OS             : ${System.getProperty("os.name")} ${System.getProperty("os.version")}
+         |CPU vCores     : $cpuInfo
+         |Heap Memory    : ${java.lang.Runtime.getRuntime.maxMemory >> 20} MB
+         |""".stripMargin
+
+    Thread.sleep(50)
+    emitln(systemInformation)
+
+    instances foreach { instance =>
+
+      emit(f"${instance.name}%-15s: ")
+      val startTime = System.currentTimeMillis()
+      try {
+        EvalUtil.evaluate(instance.command, mutable.AnyRefMap())
+        val duration = (System.currentTimeMillis() - startTime) / 1000.0
+        emitln(f"$duration%7.2f s")
+      } catch {
+        case _: Throwable =>
+          emitln("Failed")
+      }
+
+    }
+
+    if (!consoleOnly)
+      writer.close()
+
+    def emit(str: String): Unit = {
+      print(str)
+      if (!consoleOnly)
+        writer.print(str)
+    }
+
+    def emitln(str: String): Unit = {
+      println(str)
+      if (!consoleOnly)
+        writer.println(str)
+    }
+
+  }
+
+  lazy val sigar: Sigar = new Sigar
+
+  def cpuInfo: String = {
+
+    try {
+      val cpuInfo = sigar.getCpuInfoList
+      s"${cpuInfo.length} x ${cpuInfo.head.getMhz} MHz (${cpuInfo.head.getVendor} ${cpuInfo.head.getModel})"
+    } catch {
+      case exc: Throwable =>
+        exc.printStackTrace()
+        "<unavailable>"
+    }
+
+  }
+
+}

--- a/lib/pom.xml
+++ b/lib/pom.xml
@@ -1,0 +1,252 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.cgsuite</groupId>
+  <artifactId>cgsuite</artifactId>
+  <version>2.0.0-SNAPSHOT</version>
+  <packaging>pom</packaging>
+  
+  <name>${project.artifactId}</name>
+  <url>http://www.cgsuite.org/</url>
+  <description>CGSuite Libraries Parent.</description>
+  <inceptionYear>2015</inceptionYear>
+  <licenses>
+    <license>
+      <name>GNU General Public License (GPL)</name>
+      <url>http://www.gnu.org/licenses/gpl.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <properties>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <encoding>UTF-8</encoding>
+    <scala.tools.version>2.12</scala.tools.version>
+    <scala.version>2.12.13</scala.version>
+  </properties>
+
+  <repositories>
+    <repository>
+      <id>typesafe.com</id>
+      <name>Typesafe Repository</name>
+      <url>https://repo.typesafe.com/typesafe/maven-releases/</url>
+    </repository>
+  </repositories>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-compiler</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-reflect</artifactId>
+      <version>${scala.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.typesafe.scala-logging</groupId>
+      <artifactId>scala-logging_${scala.tools.version}</artifactId>
+      <version>3.9.4</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.1.2</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.11</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-text</artifactId>
+      <version>1.9</version>
+    </dependency>
+    <dependency>
+      <groupId>org.antlr</groupId>
+      <artifactId>antlr</artifactId>
+      <version>3.5.2</version>
+    </dependency>
+    <dependency>
+      <groupId>cc.redberry</groupId>
+      <artifactId>rings.scaladsl_${scala.tools.version}</artifactId>
+      <version>2.5.7</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jline</groupId>
+      <artifactId>jline</artifactId>
+      <version>3.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jline</groupId>
+      <artifactId>jline-terminal-jansi</artifactId>
+      <version>3.9.0</version>
+    </dependency>
+    <dependency>
+      <groupId>io.methvin</groupId>
+      <artifactId>directory-watcher-better-files_${scala.tools.version}</artifactId>
+      <version>0.7.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.hyperic</groupId>
+      <artifactId>sigar</artifactId>
+      <version>1.6.4</version>
+    </dependency>
+
+    <!-- Test -->
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.11</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scalatest</groupId>
+      <artifactId>scalatest_${scala.tools.version}</artifactId>
+      <version>3.0.5</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.scalacheck</groupId>
+      <artifactId>scalacheck_${scala.tools.version}</artifactId>
+      <version>1.14.0</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.antlr</groupId>
+      <artifactId>gunit</artifactId>
+      <version>3.5.2</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+
+    <sourceDirectory>src/main/scala</sourceDirectory>
+    <testSourceDirectory>src/test/scala</testSourceDirectory>
+
+    <plugins>
+
+      <!-- maven-clean -->
+      <plugin>
+        <artifactId>maven-clean-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <filesets>
+            <fileset>
+              <directory>src/main/gen</directory>
+              <includes>
+                <include>**/*</include>
+              </includes>
+              <followSymlinks>false</followSymlinks>
+            </fileset>
+          </filesets>
+        </configuration>
+      </plugin>
+
+      <!-- maven-assembly -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>3.1.0</version>
+        <configuration>
+          <descriptorRefs>
+            <descriptorRef>jar-with-dependencies</descriptorRef>
+          </descriptorRefs>
+        </configuration>
+        <executions>
+          <execution>
+            <id>assemble-all</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- maven-surefire -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.13</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+
+      <!-- scala-maven -->
+      <plugin>
+        <!-- see http://davidb.github.com/scala-maven-plugin -->
+        <groupId>net.alchim31.maven</groupId>
+        <artifactId>scala-maven-plugin</artifactId>
+        <version>3.2.1</version>
+        <executions>
+          <execution>
+            <id>scala-compile-first</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <recompileMode>incremental</recompileMode>
+              <args>
+                <arg>-feature</arg>
+                <arg>-dependencyfile</arg>
+                <arg>${project.build.directory}/.scala_dependencies</arg>
+              </args>
+            </configuration>
+          </execution>
+          <execution>
+            <id>scala-test-first</id>
+            <phase>process-test-resources</phase>
+            <goals>
+              <goal>testCompile</goal>
+            </goals>
+            <configuration>
+              <recompileMode>incremental</recompileMode>
+              <args>
+                <arg>-dependencyfile</arg>
+                <arg>${project.build.directory}/.scala_dependencies</arg>
+              </args>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <!-- scalatest-maven -->
+      <plugin>
+        <groupId>org.scalatest</groupId>
+        <artifactId>scalatest-maven-plugin</artifactId>
+        <version>1.0</version>
+        <configuration>
+          <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+          <junitxml>.</junitxml>
+          <filereports>WDF TestSuite.txt</filereports>
+          <forkMode>once</forkMode>
+          <argLine>-XX:MaxPermSize=256m</argLine>
+          <parallel>false</parallel>
+        </configuration>
+        <executions>
+          <execution>
+            <id>test</id>
+            <goals>
+              <goal>test</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+    </plugins>
+
+  </build>
+
+</project>


### PR DESCRIPTION
Adds a new tool org.cgsuite.tools.Benchmark with a standardized benchmark of representative CGSuite operations. This will help detect performance regressions in the future.

This commit also reorganizes the pomfile into separate master+library poms.