### PR TITLE
Allow def statements at Worksheet scope

### DIFF
--- a/lib/core/src/main/scala/org/cgsuite/lang/DeclarationNode.scala
+++ b/lib/core/src/main/scala/org/cgsuite/lang/DeclarationNode.scala
@@ -14,14 +14,7 @@ object DeclarationNode {
 
       case CLASS => Iterable(ClassDeclarationNode(tree, pkg))
 
-      case DEF =>
-        Iterable(MethodDeclarationNode(
-          tree,
-          IdentifierNode(tree.children(1)),
-          Modifiers(tree.head, EXTERNAL, OVERRIDE, STATIC),
-          tree.children find { _.getType == METHOD_PARAMETER_LIST } map { ParametersNode(_, Some(pkg)) },
-          tree.children find { _.getType == STATEMENT_SEQUENCE } map { StatementSequenceNode(_) }
-        ))
+      case DEF => Iterable(MethodDeclarationNode(tree, Some(pkg)))
 
       case STATIC => Iterable(InitializerBlockNode(tree, EvalNode(tree.head), Modifiers(static = Some(tree.token))))
 
@@ -183,6 +176,20 @@ object EnumElementNode {
 case class EnumElementNode(tree: Tree, idNode: IdentifierNode, modifiers: Modifiers)
   extends MemberDeclarationNode {
   val children = Seq(idNode)
+}
+
+object MethodDeclarationNode {
+
+  def apply(tree: Tree, pkg: Option[CgscriptPackage]): MethodDeclarationNode = {
+    MethodDeclarationNode(
+      tree,
+      IdentifierNode(tree.children(1)),
+      Modifiers(tree.head, EXTERNAL, OVERRIDE, STATIC),
+      tree.children find { _.getType == METHOD_PARAMETER_LIST } map { ParametersNode(_, pkg) },
+      tree.children find { _.getType == STATEMENT_SEQUENCE } map { StatementSequenceNode(_) }
+    )
+  }
+
 }
 
 case class MethodDeclarationNode(

--- a/lib/core/src/main/scala/org/cgsuite/lang/EvalNode.scala
+++ b/lib/core/src/main/scala/org/cgsuite/lang/EvalNode.scala
@@ -1,6 +1,5 @@
 package org.cgsuite.lang
 
-import org.antlr.runtime.Token
 import org.antlr.runtime.tree.Tree
 import org.cgsuite.core.Values._
 import org.cgsuite.core._
@@ -128,6 +127,10 @@ object EvalNode {
           throw EvalException("Syntax error.", tree)
         AssignToNode(tree, IdentifierNode(tree.head), EvalNode(tree.children(1)), AssignmentDeclType.Ordinary)
       case VAR => VarNode(tree)
+
+      // Function def
+
+      case DEF => DefNode(tree)
 
       // Statement sequence
 
@@ -1463,6 +1466,21 @@ object VarNode {
       case ASSIGN => AssignToNode(t, IdentifierNode(t.head), EvalNode(t.children(1)), AssignmentDeclType.VarDecl)
     }
   }
+}
+
+object DefNode {
+
+  def apply(tree: Tree): AssignToNode = {
+
+    AssignToNode(
+      tree,
+      IdentifierNode(tree.head),
+      ProcedureNode(tree, ParametersNode(tree.children(1), None).toParameters, EvalNode(tree.children(2))),
+      AssignmentDeclType.Ordinary
+    )
+
+  }
+
 }
 
 case class AssignToNode(tree: Tree, idNode: IdentifierNode, expr: EvalNode, declType: AssignmentDeclType.Value) extends EvalNode {

--- a/lib/core/src/test/scala/org/cgsuite/lang/EvalTest.scala
+++ b/lib/core/src/test/scala/org/cgsuite/lang/EvalTest.scala
@@ -336,6 +336,19 @@ class EvalTest extends CgscriptSpec {
 
   }
 
+  it should "accept outer def notation for procedures" in {
+
+    executeTests(Table(
+      header,
+      ("Procedure definition with def", "def t(x) := x + 1", "x -> x + 1"),
+      ("Statement chaining with def'ed procedure 1", "def t(x) := x + 2;", null),
+      ("Evaluation of def'ed procedure", "t(5)", "7"),
+      ("Statement chaining with def'ed procedure 2", "def t(x) := x + 3; t(5)", "8"),
+      ("Procedure definition with def block", "def u(x) begin y := x + 4; y; end", "x -> begin y := x + 4; y end"),
+      ("Procedure chaining with def block", "def u(x) begin y := x + 5; y; end; u(5)", "10")
+    ))
+  }
+
   it should "validate function calls correctly" in {
 
     testPackage declareSubpackage "validation"


### PR DESCRIPTION
Allow def statements at Worksheet scope as a synonym for function assignment. For example,

def f(x) := x + 1

on the Worksheet (or in startup.cgs or another script) is a synonym for

f := x -> x + 1