### PR TITLE
Prep for Scala 2.13 migration

### DIFF
--- a/lib/core/src/main/scala/org/cgsuite/help/HelpIndex.scala
+++ b/lib/core/src/main/scala/org/cgsuite/help/HelpIndex.scala
@@ -10,7 +10,7 @@ object HelpIndex {
 
   {
     val inputStream = HelpIndex.getClass.getResourceAsStream("docs/search-index.csv")
-    Source.fromInputStream(inputStream).getLines foreach { line =>
+    Source.fromInputStream(inputStream).getLines() foreach { line =>
       val toks = line.split(',')
       val result = Result(toks(0), toks(1), toks(2))
       val tailComponentsToIgnore = toks(3).toInt

--- a/lib/core/src/main/scala/org/cgsuite/lang/CgscriptClass.scala
+++ b/lib/core/src/main/scala/org/cgsuite/lang/CgscriptClass.scala
@@ -189,7 +189,7 @@ class CgscriptClass(
 
   val qualifiedId: Symbol = Symbol(qualifiedName)
 
-  val isPackageObject = id == 'constants
+  val isPackageObject = id == Symbol("constants")
 
   override def toString = s"\u27ea$qualifiedName\u27eb"
 
@@ -427,7 +427,7 @@ class CgscriptClass(
 
     // Force constants to declare first
     if (this != Object) {
-      pkg lookupClass 'constants foreach { constantsCls =>
+      pkg lookupClass Symbol("constants") foreach { constantsCls =>
         if (constantsCls != this) constantsCls.ensureDeclared()
       }
     }
@@ -928,15 +928,15 @@ class CgscriptClass(
     }
 
     // For efficiency, we cache lookups for some methods that get called in hardcoded locations
-    lazy val evalMethod = forceLookupMethodGroup('Eval)
-    lazy val optionsMethod = forceLookupAutoinvokeMethod('Options)
-    lazy val optionsMethodWithParameter = forceLookupMethod('Options, Vector(CgscriptClass.Player))
-    lazy val decompositionMethod = forceLookupAutoinvokeMethod('Decomposition)
-    lazy val canonicalFormMethod = forceLookupAutoinvokeMethod('CanonicalForm)
-    lazy val gameValueMethod = forceLookupAutoinvokeMethod('GameValue)
-    lazy val depthHintMethod = forceLookupAutoinvokeMethod('DepthHint)
-    lazy val toOutputMethod = forceLookupAutoinvokeMethod('ToOutput)
-    lazy val heapOptionsMethod = forceLookupMethod('HeapOptions, Vector(CgscriptClass.Integer))
+    lazy val evalMethod = forceLookupMethodGroup(Symbol("Eval"))
+    lazy val optionsMethod = forceLookupAutoinvokeMethod(Symbol("Options"))
+    lazy val optionsMethodWithParameter = forceLookupMethod(Symbol("Options"), Vector(CgscriptClass.Player))
+    lazy val decompositionMethod = forceLookupAutoinvokeMethod(Symbol("Decomposition"))
+    lazy val canonicalFormMethod = forceLookupAutoinvokeMethod(Symbol("CanonicalForm"))
+    lazy val gameValueMethod = forceLookupAutoinvokeMethod(Symbol("GameValue"))
+    lazy val depthHintMethod = forceLookupAutoinvokeMethod(Symbol("DepthHint"))
+    lazy val toOutputMethod = forceLookupAutoinvokeMethod(Symbol("ToOutput"))
+    lazy val heapOptionsMethod = forceLookupMethod(Symbol("HeapOptions"), Vector(CgscriptClass.Integer))
 
     private def forceLookupMethodGroup(id: Symbol): MethodGroup = {
       lookupMethodGroup(id) getOrElse {
@@ -1079,30 +1079,30 @@ class CgscriptClass(
 
     // Big temporary hack to populate Left and Right
     if (qualifiedName == "game.Player") {
-      classObjectRef.vars(classInfoRef.staticVarOrdinals('Left)) = Left
-      classObjectRef.vars(classInfoRef.staticVarOrdinals('Right)) = Right
+      classObjectRef.vars(classInfoRef.staticVarOrdinals(Symbol("Left"))) = Left
+      classObjectRef.vars(classInfoRef.staticVarOrdinals(Symbol("Right"))) = Right
     }
     if (qualifiedName == "game.Side") {
-      classObjectRef.vars(classInfoRef.staticVarOrdinals('Onside)) = Onside
-      classObjectRef.vars(classInfoRef.staticVarOrdinals('Offside)) = Offside
+      classObjectRef.vars(classInfoRef.staticVarOrdinals(Symbol("Onside"))) = Onside
+      classObjectRef.vars(classInfoRef.staticVarOrdinals(Symbol("Offside"))) = Offside
     }
     if (qualifiedName == "game.OutcomeClass") {
       import org.cgsuite.core.OutcomeClass._
-      classObjectRef.vars(classInfoRef.staticVarOrdinals('P)) = P
-      classObjectRef.vars(classInfoRef.staticVarOrdinals('N)) = N
-      classObjectRef.vars(classInfoRef.staticVarOrdinals('L)) = L
-      classObjectRef.vars(classInfoRef.staticVarOrdinals('R)) = R
-      classObjectRef.vars(classInfoRef.staticVarOrdinals('D)) = D
-      classObjectRef.vars(classInfoRef.staticVarOrdinals('PHat)) = PHat
-      classObjectRef.vars(classInfoRef.staticVarOrdinals('PCheck)) = PCheck
-      classObjectRef.vars(classInfoRef.staticVarOrdinals('NHat)) = NHat
-      classObjectRef.vars(classInfoRef.staticVarOrdinals('NCheck)) = NCheck
+      classObjectRef.vars(classInfoRef.staticVarOrdinals(Symbol("P"))) = P
+      classObjectRef.vars(classInfoRef.staticVarOrdinals(Symbol("N"))) = N
+      classObjectRef.vars(classInfoRef.staticVarOrdinals(Symbol("L"))) = L
+      classObjectRef.vars(classInfoRef.staticVarOrdinals(Symbol("R"))) = R
+      classObjectRef.vars(classInfoRef.staticVarOrdinals(Symbol("D"))) = D
+      classObjectRef.vars(classInfoRef.staticVarOrdinals(Symbol("PHat"))) = PHat
+      classObjectRef.vars(classInfoRef.staticVarOrdinals(Symbol("PCheck"))) = PCheck
+      classObjectRef.vars(classInfoRef.staticVarOrdinals(Symbol("NHat"))) = NHat
+      classObjectRef.vars(classInfoRef.staticVarOrdinals(Symbol("NCheck"))) = NCheck
     }
     if (qualifiedName == "cgsuite.util.Symmetry") {
       import Symmetry._
-      Map('Identity -> Identity, 'Inversion -> Inversion, 'HorizontalFlip -> HorizontalFlip, 'VerticalFlip -> VerticalFlip,
-        'Transpose -> Transpose, 'AntiTranspose -> AntiTranspose, 'ClockwiseRotation -> ClockwiseRotation,
-        'AnticlockwiseRotation -> AnticlockwiseRotation) foreach { case (symId, value) =>
+      Map(Symbol("Identity") -> Identity, Symbol("Inversion") -> Inversion, Symbol("HorizontalFlip") -> HorizontalFlip, Symbol("VerticalFlip") -> VerticalFlip,
+        Symbol("Transpose") -> Transpose, Symbol("AntiTranspose") -> AntiTranspose, Symbol("ClockwiseRotation") -> ClockwiseRotation,
+        Symbol("AnticlockwiseRotation") -> AnticlockwiseRotation) foreach { case (symId, value) =>
         classObjectRef.vars(classInfoRef.staticVarOrdinals(symId)) = value
       }
     }

--- a/lib/core/src/main/scala/org/cgsuite/lang/CgscriptPackage.scala
+++ b/lib/core/src/main/scala/org/cgsuite/lang/CgscriptPackage.scala
@@ -93,7 +93,7 @@ case class CgscriptPackage(parent: Option[CgscriptPackage], name: String) {
   }
 
   def lookupConstant(id: Symbol): Option[Resolution] = {
-    lookupClass('constants) flatMap { constantsCls =>
+    lookupClass(Symbol("constants")) flatMap { constantsCls =>
       Option(Resolver forId id findResolutionForClass constantsCls) match {
         case Some(res) if res.isResolvable => Some(res)
         case _ => None

--- a/lib/core/src/main/scala/org/cgsuite/lang/Namespace.scala
+++ b/lib/core/src/main/scala/org/cgsuite/lang/Namespace.scala
@@ -18,7 +18,7 @@ object Namespace {
     namespace
   }
 
-  def checkin(namespace: Namespace) {
+  def checkin(namespace: Namespace): Unit = {
     namespace.clear()
     pool.enqueue(namespace)
   }
@@ -31,12 +31,12 @@ class Namespace {
   var args: Map[Symbol, Any] = _
   var additions: mutable.AnyRefMap[Symbol, Any] = _
 
-  def initialize(parent: Option[Namespace], args: Map[Symbol, Any]) {
+  def initialize(parent: Option[Namespace], args: Map[Symbol, Any]): Unit = {
     this.parent = parent
     this.args = args
   }
 
-  def clear() {
+  def clear(): Unit = {
     this.parent = null
     this.args = null
     if (additions != null)
@@ -51,7 +51,7 @@ class Namespace {
     lookupInScope(symbol).orElse { parent flatMap { _.lookup(symbol) } }
   }
 
-  def put(symbol: Symbol, x: Any, declare: Boolean) {
+  def put(symbol: Symbol, x: Any, declare: Boolean): Unit = {
     if (declare || true || contains(symbol)) {
       putInScope(symbol, x)
     } else {
@@ -73,7 +73,7 @@ class Namespace {
       additions get symbol orElse (args get symbol)
   }
 
-  def putInScope(symbol: Symbol, x: Any) {
+  def putInScope(symbol: Symbol, x: Any): Unit = {
     if (additions == null)
       additions = mutable.AnyRefMap()
     additions.put(symbol, x)

--- a/lib/core/src/main/scala/org/cgsuite/lang/Profiler.scala
+++ b/lib/core/src/main/scala/org/cgsuite/lang/Profiler.scala
@@ -39,9 +39,9 @@ object Profiler {
     Profiler.clear()
     Profiler.setEnabled(enabled = profile)
     val start = JSystem.nanoTime()
-    Profiler.start('Main)
+    Profiler.start(Symbol("Main"))
     val result = node.evaluate(domain).toString
-    Profiler.stop('Main)
+    Profiler.stop(Symbol("Main"))
     val totalDuration = JSystem.nanoTime() - start
     Profiler.setEnabled(enabled = false)
     assert(
@@ -54,10 +54,10 @@ object Profiler {
   private def _profilerAvgNanos = {
     (0 to 500).map { _ =>
       (0 to 5000).foreach { _ =>
-        Profiler.start('ProfileProfiler)
-        Profiler.stop('ProfileProfiler)
+        Profiler.start(Symbol("ProfileProfiler"))
+        Profiler.stop(Symbol("ProfileProfiler"))
       }
-      val result = Profiler.totals('ProfileProfiler).timing / 5000
+      val result = Profiler.totals(Symbol("ProfileProfiler")).timing / 5000
       totals.clear()
       result
     }.sorted.apply(250)
@@ -78,7 +78,7 @@ object Profiler {
   def setEnabled(enabled: Boolean) {
     this.enabled = enabled
     if (enabled && profilerAvgNanos == -1L) {
-      whitelist = Set('ProfileProfiler)
+      whitelist = Set(Symbol("ProfileProfiler"))
       profilerAvgNanos = _profilerAvgNanos
       println("Average profiler latency: " + profilerAvgNanos + " ns")
       whitelist = Set.empty

--- a/lib/core/src/main/scala/org/cgsuite/lang/Profiler.scala
+++ b/lib/core/src/main/scala/org/cgsuite/lang/Profiler.scala
@@ -9,13 +9,13 @@ import scala.collection.mutable
 
 object Profiler {
 
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     CgscriptClass.Object.ensureInitialized()
     profileStatement("""game.grid.Clobber("xoxo|oxox|xoxo").CanonicalForm""", "0")
     profileStatement("""game.grid.Clobber("xoxo|oxox|xoxo|ox..").CanonicalForm.StopCount""", "20101")
   }
 
-  def profileStatement(statement: String, expectedResult: String) {
+  def profileStatement(statement: String, expectedResult: String): Unit = {
     // Warm-up
     CgscriptClass.clearAll()
     //evalForProfiler(statement, expectedResult, profile = false)
@@ -75,7 +75,7 @@ object Profiler {
   private val stack = mutable.Stack[(Symbol, Totals)]()
   private val totals = mutable.AnyRefMap[Symbol, Totals]()
 
-  def setEnabled(enabled: Boolean) {
+  def setEnabled(enabled: Boolean): Unit = {
     this.enabled = enabled
     if (enabled && profilerAvgNanos == -1L) {
       whitelist = Set(Symbol("ProfileProfiler"))
@@ -87,11 +87,11 @@ object Profiler {
     }
   }
 
-  def setWhitelist(symbols: Symbol*) {
+  def setWhitelist(symbols: Symbol*): Unit = {
     whitelist = Set(symbols : _*)
   }
 
-  def start(key: Symbol) {
+  def start(key: Symbol): Unit = {
     if (enabled && (whitelist.isEmpty || whitelist.contains(key))) {
       val now = JSystem.nanoTime
       if (stack.nonEmpty) {
@@ -102,7 +102,7 @@ object Profiler {
     }
   }
 
-  def stop(key: Symbol) {
+  def stop(key: Symbol): Unit = {
     if (enabled && (whitelist.isEmpty || whitelist.contains(key))) {
       val now = JSystem.nanoTime
       val (key2, totals) = stack.pop()
@@ -128,7 +128,7 @@ object Profiler {
     }
   }
 
-  def clear() {
+  def clear(): Unit = {
     totals.clear()
     stack.clear()
   }

--- a/lib/core/src/main/scala/org/cgsuite/lang/StandardObject.scala
+++ b/lib/core/src/main/scala/org/cgsuite/lang/StandardObject.scala
@@ -14,7 +14,7 @@ class StandardObject(val cls: CgscriptClass, val objArgs: Array[Any], val enclos
   private[lang] var vars: Array[Any] = _
   init()
 
-  def init() {
+  def init(): Unit = {
     vars = new Array[Any](cls.classInfo.instanceVarLookup.size)
     JSystem.arraycopy(objArgs, 0, vars, 0, objArgs.length)
     cls.ancestors foreach { ancestor =>

--- a/lib/core/src/main/scala/org/cgsuite/lang/node/AssignToNode.scala
+++ b/lib/core/src/main/scala/org/cgsuite/lang/node/AssignToNode.scala
@@ -9,7 +9,7 @@ case class AssignToNode(tree: Tree, idNode: IdentifierNode, expr: EvalNode, decl
   // TODO Catch illegal assignment to immutable object member (during elaboration)
   // TODO Catch illegal assignment to constant
   override val children = Vector(idNode, expr)
-  override def elaborate(scope: ElaborationDomain) {
+  override def elaborate(scope: ElaborationDomain): Unit = {
     // If we're package-external (Worksheet/REPL scope) and scopeStack has size one (we're not
     // in any nested subscope), then we treat idNode as a dynamic var.
     if (declType == AssignmentDeclType.VarDecl && !scope.isToplevelWorksheet) {

--- a/lib/core/src/main/scala/org/cgsuite/lang/node/DotNode.scala
+++ b/lib/core/src/main/scala/org/cgsuite/lang/node/DotNode.scala
@@ -15,7 +15,7 @@ case class DotNode(tree: Tree, obj: EvalNode, idNode: IdentifierNode) extends Ev
   var isElaborated = false
   var classResolution: CgscriptClass = _
   var constantResolution: Resolution = _
-  override def elaborate(scope: ElaborationDomain) {
+  override def elaborate(scope: ElaborationDomain): Unit = {
     antecedentAsPackage flatMap { _.lookupClass(idNode.id) } match {
       case Some(cls) => classResolution = cls
       case None =>

--- a/lib/core/src/main/scala/org/cgsuite/lang/node/IdentifierNode.scala
+++ b/lib/core/src/main/scala/org/cgsuite/lang/node/IdentifierNode.scala
@@ -35,7 +35,7 @@ case class IdentifierNode(tree: Tree, id: Symbol) extends EvalNode {
 
   override val children = Vector.empty
 
-  override def elaborate(scope: ElaborationDomain) {
+  override def elaborate(scope: ElaborationDomain): Unit = {
     // Can this be resolved as a Class name? Check first in local package scope, then in default package scope
     scope.pkg flatMap { _ lookupClass id } orElse (CgscriptPackage lookupClass id) match {
       case Some(cls) => classResolution = {

--- a/lib/core/src/main/scala/org/cgsuite/lang/node/LoopNode.scala
+++ b/lib/core/src/main/scala/org/cgsuite/lang/node/LoopNode.scala
@@ -82,7 +82,7 @@ case class LoopNode(
     case _ => None
   }
 
-  override def elaborate(scope: ElaborationDomain) {
+  override def elaborate(scope: ElaborationDomain): Unit = {
     forId match {
       case Some(idNode) =>
         scope.pushScope()

--- a/lib/core/src/main/scala/org/cgsuite/output/GridOutput.scala
+++ b/lib/core/src/main/scala/org/cgsuite/output/GridOutput.scala
@@ -60,7 +60,7 @@ trait GenGridOutput extends AbstractOutput {
   lazy val cellSize = GridOutput.iconDimensions(icons, forceSquares = false)
   lazy val size = GridOutput.imageDimensions(grid, cellSize, 1, 1)
 
-  def write(out: PrintWriter, mode: Output.Mode) {
+  def write(out: PrintWriter, mode: Output.Mode): Unit = {
     mode match {
       case Output.Mode.PLAIN_TEXT => out.print(alt)
       case _ => throw new UnsupportedOperationException
@@ -69,7 +69,7 @@ trait GenGridOutput extends AbstractOutput {
 
   override def getSize(preferredWidth: Int): Dimension = size
 
-  def paint(g: Graphics2D, preferredWidth: Int) {
+  def paint(g: Graphics2D, preferredWidth: Int): Unit = {
 
     val totalSize: Dimension = GridOutput.imageDimensions(grid, cellSize, 1, 1)
     g.setBackground(Color.white)

--- a/lib/core/src/main/scala/org/cgsuite/output/IntensityPlotOutput.scala
+++ b/lib/core/src/main/scala/org/cgsuite/output/IntensityPlotOutput.scala
@@ -17,13 +17,13 @@ case class IntensityPlotOutput(array: Seq[Seq[RationalNumber]], unitSize: Int = 
   val maxValue = array.map { _.max(ord) }.max(ord)
   val span = (maxValue - minValue).toFloat
 
-  def write(out: PrintWriter, mode: Mode) {
+  def write(out: PrintWriter, mode: Mode): Unit = {
     out print s"<$rowCount x $colCount IntensityPlot>"
   }
 
   def getSize(preferredWidth: Int): Dimension = new Dimension(colCount * unitSize, rowCount * unitSize)
 
-  def paint(graphics: Graphics2D, preferredWidth: Int) {
+  def paint(graphics: Graphics2D, preferredWidth: Int): Unit = {
 
     for (i <- array.indices; j <- array(i).indices) {
       val color: Float = (array(i)(j) - minValue).toFloat / span

--- a/lib/core/src/main/scala/org/cgsuite/util/TranspositionTable.scala
+++ b/lib/core/src/main/scala/org/cgsuite/util/TranspositionTable.scala
@@ -6,7 +6,7 @@ class TranspositionTable[T] {
 
   private val map = mutable.AnyRefMap[AnyRef, T]()
 
-  def put(k: AnyRef, v: T) {
+  def put(k: AnyRef, v: T): Unit = {
     map.put(k, v)
   }
 


### PR DESCRIPTION
Eliminates the use of Symbol literals and procedure syntax, which are deprecated in Scala 2.13.