### PR TITLE
Implement Subordinate (inverse ordinal sum) calculation for short games and stoppers

### DIFF
--- a/lib/core/src/main/resources/org/cgsuite/lang/resources/game/CanonicalStopper.cgs
+++ b/lib/core/src/main/resources/org/cgsuite/lang/resources/game/CanonicalStopper.cgs
@@ -84,6 +84,20 @@ system class CanonicalStopper extends Game, StopperSidedValue
     */
   external def StrongStop(player as Player);
 
+  /** The subordinate of this game to the specified base.
+    *
+    * `G.Subordinate(B)` is the unique `H` such that `G = B:H`. The base `B` must be a short game
+    * (but not necessarily in canonical form). If `G` cannot be expressed in the form `B:H`, then
+    * an error will occur.
+    *
+    * \display{(3/8).Subordinate(1)}
+    *
+    * Subordinating to a non-canonical base:
+    *
+    * \display{^.Subordinate('{*|*}')}
+    */
+  external def Subordinate(base as Game);
+
   /** Shorthand for the game `{0||0|-this}`.
     */
   def Tiny := {0||0|-this};

--- a/lib/core/src/test/scala/org/cgsuite/lang/GameTest.scala
+++ b/lib/core/src/test/scala/org/cgsuite/lang/GameTest.scala
@@ -202,6 +202,9 @@ class GameTest extends CgscriptSpec {
       ("(1/8).Subordinate(1)", "-3"),
       ("(^.PowTo(5)+*).Subordinate(*)", "5"),
       ("*.Subordinate(1)", "!!That game cannot be subordinated to the specified base."),
+      ("(+-1).Subordinate(0)", "+-1"),
+      ("(+-1).Subordinate(+-1)", "0"),
+      ("(-13/16).Subordinate(-1)", "3/8"),
       ("^.PowTo(5).Subordinate('{*|*}')", "5")    // Subordinating to a non-canonical base
     )
 

--- a/lib/core/src/test/scala/org/cgsuite/lang/GameTest.scala
+++ b/lib/core/src/test/scala/org/cgsuite/lang/GameTest.scala
@@ -198,7 +198,11 @@ class GameTest extends CgscriptSpec {
       ("{0||0|-2}.PowTo({5|pass})", "{{Tiny(2)||0|-2|||0|-2||||0|-2}||0|-2|||{0|-2},pass}"),
       ("{0||0|-2}.PowTo(on)", "{pass||0|-2}"),
       ("(+-1).PowTo(3)", "{1,{1,+-1|-1}|-1}"),
-      ("(+-1).Pow(3)", "!!Invalid base for `Pow` operation (base must be of the form {0|H}).")
+      ("(+-1).Pow(3)", "!!Invalid base for `Pow` operation (base must be of the form {0|H})."),
+      ("(1/8).Subordinate(1)", "-3"),
+      ("(^.PowTo(5)+*).Subordinate(*)", "5"),
+      ("*.Subordinate(1)", "!!That game cannot be subordinated to the specified base."),
+      ("^.PowTo(5).Subordinate('{*|*}')", "5")    // Subordinating to a non-canonical base
     )
 
     executeTests(Table(
@@ -221,6 +225,13 @@ class GameTest extends CgscriptSpec {
     val instances = Seq(
       ("upon.Downsum(^.Pow(on))", "^[on]"),
       ("upon.DownsumVariety(^.Pow(on))", "v<on>"),
+      ("over.Subordinate(1)", "off"),
+      ("(upon+*).Subordinate(*)", "on"),
+      ("upon.Subordinate('{*|*}')", "on"),
+      ("{0,*|0,pass}.Subordinate(*)", "over"),
+      ("on.Subordinate(1)", "on"),
+      ("over.Subordinate(1)", "off"),
+      ("on.Subordinate(*)", "!!That game cannot be subordinated to the specified base."),
       ("upon.Upsum(^.Pow(on))", "{0|^<on>*}"),
       ("upon.UpsumVariety(^.Pow(on))", "v<on>")
     )


### PR DESCRIPTION
Adds a method `CanonicalStopper.Subordinate(B)` that calculates the unique H for which G = B:H (or raises an error if no such H exists). B is permitted to be any short game, not necessarily canonical.

There is a separate implementation for `CanonicalShortGame`s that uses a recursive calculation and is more efficient.