### PR TITLE
Fix a bug in List.Sorted when the list contains non-dyadic rationals

### DIFF
--- a/lib/core/src/main/scala/org/cgsuite/lang/UniversalOrdering.scala
+++ b/lib/core/src/main/scala/org/cgsuite/lang/UniversalOrdering.scala
@@ -1,6 +1,6 @@
 package org.cgsuite.lang
 
-import org.cgsuite.core.CanonicalShortGame
+import org.cgsuite.core.{CanonicalShortGame, RationalNumber}
 import org.cgsuite.core.misere.MisereCanonicalGame
 import org.cgsuite.util.Coordinates
 
@@ -12,6 +12,7 @@ object UniversalOrdering extends Ordering[Any] {
       case (null, null) => 0
       case (null, _) => -1
       case (_, null) => 1
+      case (x: RationalNumber, y: RationalNumber) => x compare y      // This is consistent with CanonicalShortGame.DeterministicOrdering
       case (g: CanonicalShortGame, h: CanonicalShortGame) => CanonicalShortGame.DeterministicOrdering.compare(g, h)
       case (_: CanonicalShortGame, _) => -1
       case (_, _: CanonicalShortGame) => 1

--- a/lib/core/src/test/scala/org/cgsuite/lang/CgsuiteLangTest.scala
+++ b/lib/core/src/test/scala/org/cgsuite/lang/CgsuiteLangTest.scala
@@ -58,6 +58,7 @@ class CgsuiteLangTest extends CgscriptSpec {
           |--+---+--
           |9""".stripMargin),
       ("List: Sorted", "[[5,3,7],[1,6,3],[9,2,8]].Sorted", "[[1,6,3],[5,3,7],[9,2,8]]"),
+      ("List: Sorted with non-dyadic rationals", "[92/47, 41/23, 9/4, 3].Sorted", "[41/23,92/47,9/4,3]"),
       ("List: SortedWith", "[[5,3,7],[1,6,3],[9,2,8]].SortedWith((a, b) -> a[2] - b[2])", "[[9,2,8],[5,3,7],[1,6,3]]"),
       ("List: SortedWith invalid comparator", "[[5,3,7],[1,6,3],[9,2,8]].SortedWith((a, b) -> \"I am a banana.\")",
         "!!Expected `game.Integer`; found `cgsuite.lang.String`."),


### PR DESCRIPTION
Fixes a bug in List.Sorted when the list contains non-dyadic rationals. For example:

`[92/47, 41/23, 9/4, 3].Sorted`